### PR TITLE
Enable matterbridge message pasting

### DIFF
--- a/matterbridge/Dockerfile
+++ b/matterbridge/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.17 as builder
 
 WORKDIR /
-RUN go install github.com/42wim/matterbridge@v1.23.2
+RUN go install github.com/lineageos-infra/matterbridge@latest
 RUN go install github.com/hairyhenderson/gomplate/v3/cmd/gomplate@v3.10.0
 RUN go install github.com/DarthSim/hivemind@v1.0.6
 

--- a/matterbridge/matterbridge.toml.tpl
+++ b/matterbridge/matterbridge.toml.tpl
@@ -9,6 +9,12 @@ SkipTLSVerify=true
 Label="irc"
 RemoteNickFormat="[{LABEL}] <{NICK}> "
 
+PasteDomain="p.lineageos.org"
+PasteCodeblocks=true
+PasteLongMessages=true
+PastePreviewLines=3
+PasteAPIKey="{{ .Env.PASTE_API_KEY }}"
+
 [discord.lineageos]
 Token="{{ .Env.DISCORD_TOKEN }}"
 Server="628008280605589549"


### PR DESCRIPTION
Requires lineageos-infra/matterbridge#2 and lineageos-infra/matterbridge#4 to go in, as well as creating a new tag (with the changes included) that Go can use. `latest` in the Dockerfile may have to be replaced with the tag name depending on how Go feels today.

The `PASTE_API_KEY` environment variable can either have an API key or be empty, not sure how fly will behave if it's entirely unset.